### PR TITLE
fix(issues): prevent collapsed sub-issues from leaking as orphans

### DIFF
--- a/src/renderer/components/About/UpdateStatus.tsx
+++ b/src/renderer/components/About/UpdateStatus.tsx
@@ -3,10 +3,11 @@
 /**
  * UpdateStatus — Inline update status block rendered inside AboutDialog.
  *
- * Three visual states:
+ * Four visual states:
  *   1. Checking — spinner with "Checking for updates..."
- *   2. Up to date — green check with last-checked timestamp
- *   3. Update available — highlighted card with version + action buttons
+ *   2. Update available — highlighted card with version + action buttons
+ *   3. Never checked — only "Check for Updates" button (before first auto-check)
+ *   4. Up to date — green check with last-checked timestamp
  */
 
 import type { TFunction } from 'i18next'
@@ -76,18 +77,30 @@ export function UpdateStatus(): React.JSX.Element {
     )
   }
 
-  // State: Up to date
+  // State: Never checked — no result yet (e.g. within the 30s startup delay)
+  if (lastCheckedAt === null) {
+    return (
+      <div className="flex flex-col items-center gap-1 mt-2">
+        <button
+          onClick={checkForUpdates}
+          className="text-[10px] text-[hsl(var(--primary))] hover:underline"
+        >
+          {t('update.checkNow')}
+        </button>
+      </div>
+    )
+  }
+
+  // State: Up to date (at least one check has completed)
   return (
     <div className="flex flex-col items-center gap-1 mt-2">
       <div className="flex items-center gap-1.5 text-xs text-emerald-600 dark:text-emerald-400">
         <Check className="h-3 w-3" aria-hidden="true" />
         {t('update.upToDate')}
       </div>
-      {lastCheckedAt && (
-        <p className="text-[10px] text-[hsl(var(--muted-foreground)/0.6)]">
-          {t('update.lastChecked', { time: formatRelativeTime(lastCheckedAt, t) })}
-        </p>
-      )}
+      <p className="text-[10px] text-[hsl(var(--muted-foreground)/0.6)]">
+        {t('update.lastChecked', { time: formatRelativeTime(lastCheckedAt, t) })}
+      </p>
       <button
         onClick={checkForUpdates}
         className="mt-1 text-[10px] text-[hsl(var(--primary))] hover:underline"

--- a/src/renderer/components/IssuesView/IssueGroupedList.tsx
+++ b/src/renderer/components/IssuesView/IssueGroupedList.tsx
@@ -99,10 +99,20 @@ function buildDisplayEntries(
     }
   }
 
-  // Include orphan children (whose parent wasn't in this slice)
+  // Include orphan children (whose parent wasn't in this slice).
+  // Children whose parent IS in this slice but collapsed are intentionally
+  // hidden — they are not orphans and must be skipped.
   const shownIds = new Set(result.map((e) => e.issue.id))
+  const topLevelIds = new Set(topLevel.map((i) => i.id))
   for (const issue of issues) {
     if (!shownIds.has(issue.id)) {
+      if (
+        issue.parentIssueId &&
+        topLevelIds.has(issue.parentIssueId) &&
+        collapsedParents.has(issue.parentIssueId)
+      ) {
+        continue
+      }
       result.push({
         issue,
         isChild: !!issue.parentIssueId,


### PR DESCRIPTION
## Summary

The orphan detection in `buildDisplayEntries()` could not distinguish between true orphans (parent not in current slice) and intentionally collapsed children. This caused collapsed sub-issues to reappear at the list tail, visually appearing under unrelated issues.

## Changes

- **Fix sub-issue collapse leak** — Add a guard in the orphan detection loop: if a child's parent exists in the current top-level set and is collapsed, skip it instead of treating it as an orphan. Covers both flat and grouped rendering modes.
- **Add "never checked" update state** — `UpdateStatus` now shows a minimal "Check for Updates" button before the first auto-check completes, instead of incorrectly showing "Up to date".

## Test Plan

- [ ] CI passes (lint, typecheck, test, build)
- [ ] Manual: create parent issue with 2+ sub-issues → collapse → verify sub-issues are fully hidden, not relocated
- [ ] Manual: grouped mode (by status) with parent/children in same group → collapse → verify same fix
- [ ] Manual: grouped mode with parent/children in different groups → children still show as orphans in their group (not broken)
- [ ] Manual: open About dialog before first update check → see "Check for Updates" button instead of green checkmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)