### PR TITLE
fix(provider): sync base URL edits to stored credentials

### DIFF
--- a/electron/services/provider/providerService.ts
+++ b/electron/services/provider/providerService.ts
@@ -140,6 +140,8 @@ export class ProviderService {
           `Re-authentication failed for "${updated.name}": ${result.error ?? 'unknown reason'}`,
         )
       }
+    } else if (patch.credentialConfig) {
+      await this.syncStoredCredentialConfig(updated)
     }
 
     const current = this.deps.getProviderSettings()
@@ -419,6 +421,44 @@ export class ProviderService {
     patch: Partial<Omit<ProviderProfile['credential'], 'type'>>,
   ): ProviderProfile['credential'] {
     return { ...current, ...patch } as ProviderProfile['credential']
+  }
+
+  private async syncStoredCredentialConfig(profile: ProviderProfile): Promise<void> {
+    const adapter = this.tryBuildAdapter(profile)
+    if (!adapter?.getCredential) return
+
+    const current = await adapter.getCredential()
+    const apiKey = current?.apiKey?.trim()
+    if (!apiKey) return
+
+    let authParams: Record<string, unknown> | null = null
+    switch (profile.credential.type) {
+      case 'anthropic-compat-proxy':
+        authParams = {
+          apiKey,
+          baseUrl: profile.credential.baseUrl,
+          authStyle: profile.credential.authStyle,
+        }
+        break
+      case 'openai-compat-proxy':
+        authParams = {
+          apiKey,
+          baseUrl: profile.credential.baseUrl,
+        }
+        break
+      case 'claude-subscription':
+      case 'anthropic-api':
+      case 'openai-direct':
+      case 'gemini':
+        return
+    }
+
+    const result = await adapter.authenticate(authParams)
+    if (!result.authenticated) {
+      throw new Error(
+        `Credential configuration update failed for "${profile.name}": ${result.error ?? 'unknown reason'}`,
+      )
+    }
   }
 
   private resolveProtocol(profile: ProviderProfile): 'anthropic' | 'openai' | 'gemini' {

--- a/tests/unit/provider/providerService.test.ts
+++ b/tests/unit/provider/providerService.test.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from 'vitest'
+import { ProviderService } from '../../../electron/services/provider/providerService'
+import type { ProviderSettings } from '../../../src/shared/types'
+import {
+  asProviderProfileId,
+  credentialKeyFor,
+  type ProviderProfile,
+} from '../../../src/shared/providerProfile'
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: (s: string) => Buffer.from(s, 'utf-8'),
+    decryptString: (b: Buffer) => b.toString('utf-8'),
+  },
+}))
+
+class FakeStore {
+  private readonly state = new Map<string, unknown>()
+
+  async get<K extends string>(key: K): Promise<unknown> {
+    return this.state.get(key)
+  }
+
+  async getAs<U>(key: string): Promise<U | undefined> {
+    const v = this.state.get(key)
+    return v !== undefined ? (v as U) : undefined
+  }
+
+  async update<K extends string>(key: K, v: unknown): Promise<void> {
+    this.state.set(key, v)
+  }
+
+  async updateAs<U>(key: string, v: U): Promise<void> {
+    this.state.set(key, v as unknown)
+  }
+
+  async remove(key: string): Promise<void> {
+    this.state.delete(key)
+  }
+
+  async removeAt(key: string): Promise<void> {
+    this.state.delete(key)
+  }
+}
+
+describe('ProviderService', () => {
+  it('keeps OpenAI-compatible runtime baseUrl in sync when editing without a new API key', async () => {
+    const profileId = asProviderProfileId('prof_openai_1')
+    const profile: ProviderProfile = {
+      id: profileId,
+      name: 'OpenAI-compatible',
+      credential: {
+        type: 'openai-compat-proxy',
+        baseUrl: 'https://api.example.test',
+      },
+      preferredModel: 'gpt-5.4',
+      createdAt: '2026-04-20T00:00:00.000Z',
+      updatedAt: '2026-04-20T00:00:00.000Z',
+    }
+    let settings: ProviderSettings = {
+      profiles: [profile],
+      defaultProfileId: profileId,
+    }
+    const store = new FakeStore()
+    await store.updateAs(credentialKeyFor(profileId), {
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.example.test',
+    })
+    const service = new ProviderService({
+      dispatch: vi.fn(),
+      credentialStore: store as unknown as import('../../../electron/services/provider/credentialStore').CredentialStore,
+      getProviderSettings: () => settings,
+      updateProviderSettings: async (patch) => {
+        settings = { ...settings, ...patch }
+        return settings
+      },
+    })
+
+    await service.updateProfile(profileId, {
+      credentialConfig: { baseUrl: 'https://api.example.test/v1' },
+    })
+
+    await expect(service.getProviderEnvForProfile(profileId)).resolves.toMatchObject({
+      OPENAI_BASE_URL: 'https://api.example.test/v1',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Sync provider credential config when Base URL changes without re-entering the API key
- Preserve the existing API key while updating runtime Base URL
- Add a regression test for OpenAI-compatible Base URL edits

## Verification
- pnpm exec vitest run tests/unit/provider/providerService.test.ts tests/unit/provider/openai.test.ts
- pnpm exec tsc --noEmit -p tsconfig.node.json